### PR TITLE
Reuse config internally

### DIFF
--- a/lib/file-loader.js
+++ b/lib/file-loader.js
@@ -11,7 +11,7 @@ const fileLoader = (loader) => {
     loadFiles(specFiles);
   };
 
-return {
+  return {
     load
   };
 };

--- a/lib/file-loader.js
+++ b/lib/file-loader.js
@@ -1,16 +1,13 @@
 const findFilesInDirectory = require('./utils/find-files-in-directory');
 
 const fileLoader = (loader) => {
-
-  const loadFiles = (pathToTheFiles) => pathToTheFiles.forEach(loader);
-
+  const loadOneFileWithLoader = (fileName) => loader(fileName);  
+  const loadFiles = (pathToTheFiles) => pathToTheFiles.forEach(loadOneFileWithLoader);
   const load = (path) => {
     const files = findFilesInDirectory(path);
     const specFiles = files.filter(file => file.indexOf('.spec') > -1);
-
     loadFiles(specFiles);
   };
-
   return {
     load
   };

--- a/lib/kavun.js
+++ b/lib/kavun.js
@@ -4,7 +4,7 @@ const uuidv4 = require("uuid/v4");
 const { startTimer } = require("./utils/time-tracker");
 
 const processId = uuidv4();
-startTimer(processId)
+startTimer(processId);
 
 const runner = require('./runner');
 const { unitCollector } = require('./index');
@@ -13,10 +13,6 @@ const fileLoader = require('./file-loader');
 const loader = fileLoader(require);
 const path = process.argv[2];
 
-if(path === undefined) {
-  loader.load(`${process.cwd()}/tests`);
-} else {
-  loader.load(`${process.cwd()}/${path}`);
-}
+loader.load(`${process.cwd()}/${path}`);
 
 runner(unitCollector, processId);

--- a/lib/unit-collector.js
+++ b/lib/unit-collector.js
@@ -1,12 +1,15 @@
 class UnitCollector {
   constructor() {
-    this.numberOfSpecs = 0;
+    this._numberOfSpecs = 0;
     this.units = [];
     this._activeSpecs = [];
   }
 
   get numberOfUnits() {
     return this.units.length;
+  }
+  get numberOfSpecs() {
+    return this._numberOfSpecs;
   }
 
   addUnit(description, testFunction, options = {}) {
@@ -16,7 +19,7 @@ class UnitCollector {
   addSpec(description, specCallback) {
     this._activeSpecs.push(description);
     specCallback();
-    this.numberOfSpecs++;
+    this._numberOfSpecs++;
     this._activeSpecs.pop();
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A test framework for Javascript",
   "bin": "./lib/kavun.js",
   "scripts": {
-    "test": "node lib/kavun.js"
+    "test": "node lib/kavun.js tests"
   },
   "repository": {
     "type": "git",

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -131,4 +131,13 @@ spec('A `SpecCollector`', () => {
       });
     });
   });
+  
+  spec('API, implementation specifics', () => {
+    unit('`numberOfSpecs` can`t be modified', () => {
+      const specCollector = new SpecCollector();
+      specCollector.addSpec('', () => {});
+      specCollector.numberOfSpecs = 0;
+      assert.equal(specCollector.numberOfSpecs, 1);
+    });
+  });
 });

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -123,22 +123,21 @@ spec('A `SpecCollector`', () => {
     });
   });
   
-  unit('stores specs', () => {
-    const specCollector = new SpecCollector();
-
-    const noop = () => {};
-    const description = 'unit';
-    specCollector.addSpec('spec', () => {
-      specCollector.addSpec('spec1', () => {
-        specCollector.addUnit(description, noop);
+  spec('collecting specs (suites) via `addSpec()`', () => {
+    unit('stores specs', () => {
+      const specCollector = new SpecCollector();
+      const description = 'unit';
+      specCollector.addSpec('spec', () => {
+        specCollector.addSpec('spec1', () => {
+          specCollector.addUnit(description, noop);
+        });
+      });
+  
+      specCollector.withEachUnit(unit => {
+        assert(unit.specs, ['spec', 'spec1']);
+        assert(unit.description, description);
+        assert(unit.testFunction, noop);
       });
     });
-
-    const doWith = (unit) => {
-      assert(unit.specs, ['spec', 'spec1']);
-      assert(unit.description, description);
-      assert(unit.testFunction, noop);
-    };
-    specCollector.withEachUnit(doWith);
   });
 });

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -53,11 +53,11 @@ spec('A `SpecCollector`', () => {
     });
   });
 
-  unit('When code inside spec throws, specCollector should stop.', () => {
+  unit('when a spec throws, it lets the error bubble up', () => {
     const specCollector = new SpecCollector();
 
     const fn = () => {
-      specCollector.addSpec('spec with one unit', () => {
+      specCollector.addSpec('spec that throws', () => {
         throw Error();
       });
     };

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -2,39 +2,43 @@ const assert = require('assert');
 const { spec, unit } = require('../lib');
 const SpecCollector = require('../lib/unit-collector');
 
-spec('Given a `SpecCollector`', () => {
-  spec('provides statistics, when provided', () => {
-    unit('1 unit, it finds 1 unit.', () => {
-      const specCollector = new SpecCollector();
-      specCollector.addUnit('1 unit', () => {});
-  
-      assert.equal(specCollector.numberOfUnits, 1);
-    });
-  
-    unit('multiple units, it finds them.', () => {
-      const specCollector = new SpecCollector();
-      specCollector.addUnit('1 unit', () => {});
-      specCollector.addUnit('1 unit', () => {});
-  
-      assert.equal(specCollector.numberOfUnits, 2);
-    });
-  
-    unit('unit inside spec, it finds the unit.', () => {
-      const specCollector = new SpecCollector();
-      specCollector.addSpec('spec with one unit', () => {
+spec('A `SpecCollector`', () => {
+  spec('provides statistics', () => {
+    spec('the number of units (via `numberOfUnits`), when provided', () => {
+      unit('1 unit, it finds 1 unit.', () => {
+        const specCollector = new SpecCollector();
         specCollector.addUnit('1 unit', () => {});
+    
+        assert.equal(specCollector.numberOfUnits, 1);
       });
-  
-      assert.equal(specCollector.numberOfUnits, 1);
+    
+      unit('multiple units, it finds them.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addUnit('1 unit', () => {});
+        specCollector.addUnit('1 unit', () => {});
+    
+        assert.equal(specCollector.numberOfUnits, 2);
+      });
+    
+      unit('unit inside spec, it finds the unit.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addSpec('spec with one unit', () => {
+          specCollector.addUnit('1 unit', () => {});
+        });
+    
+        assert.equal(specCollector.numberOfUnits, 1);
+      });
     });
   
-    unit('unit inside spec, it finds the spec.', () => {
-      const specCollector = new SpecCollector();
-      specCollector.addSpec('spec with one unit', () => {
-        specCollector.addUnit('1 unit', () => {});
+    spec('the number of specs (via `numberOfSpecs`), when provided', () => {
+      unit('a unit inside a spec, it finds the spec.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addSpec('spec with one unit', () => {
+          specCollector.addUnit('1 unit', () => {});
+        });
+    
+        assert.equal(specCollector.numberOfSpecs, 1);
       });
-  
-      assert.equal(specCollector.numberOfSpecs, 1);
     });
   });
 

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -111,12 +111,11 @@ spec('A `SpecCollector`', () => {
     });
   
     unit('collects timeout option for units', () => {
-      const specCollector = new SpecCollector();
       const description = 'my desc';
       const timeout = 1000;
       const referenceFunction = () => {};
   
-      specCollector.addUnit(description, referenceFunction, { timeout });
+      const specCollector = addUnit(description, referenceFunction, { timeout });
   
       const doWith = (unit) => {
         assert(unit.description, description);

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -103,7 +103,7 @@ spec('A `SpecCollector`', () => {
       assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
     });
   
-    unit('collects unit`s description and function', () => {
+    unit('stores unit`s description and function', () => {
       const description = 'my desc';
       const referenceFunction = () => {};
   
@@ -112,7 +112,7 @@ spec('A `SpecCollector`', () => {
       assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
     });
   
-    unit('collects timeout option for units', () => {
+    unit('stores timeout option for units', () => {
       const description = 'my desc';
       const timeout = 1000;
       const referenceFunction = () => {};
@@ -123,7 +123,7 @@ spec('A `SpecCollector`', () => {
     });
   });
   
-  unit('collects specs.', () => {
+  unit('stores specs', () => {
     const specCollector = new SpecCollector();
 
     const noop = () => {};

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -21,13 +21,11 @@ spec('A `SpecCollector`', () => {
       specCollector.addUnit(desc, testFn, options);
       return specCollector;
     };
-
     const valuesForAttribute = (specCollector, attribute) => {
       const values = [];
       specCollector.withEachUnit(unit => values.push(unit[attribute]));
       return values;
     };
-
     const descriptionsOf = (specCollector) =>
       valuesForAttribute(specCollector, 'description');
     const testFunctionsOf = (specCollector) =>
@@ -56,7 +54,6 @@ spec('A `SpecCollector`', () => {
     unit('stores unit`s description and function', () => {
       const description = 'my desc';
       const referenceFunction = () => {};
-  
       const specCollector = addUnit(description, referenceFunction);
       assert.deepEqual(descriptionsOf(specCollector), [description]);
       assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
@@ -82,7 +79,6 @@ spec('A `SpecCollector`', () => {
           specCollector.addUnit(description, noop);
         });
       });
-  
       specCollector.withEachUnit(unit => {
         assert(unit.specs, ['spec', 'spec1']);
         assert(unit.description, description);
@@ -96,7 +92,6 @@ spec('A `SpecCollector`', () => {
       unit('1 unit, it finds 1 unit.', () => {
         const specCollector = new SpecCollector();
         specCollector.addUnit('1 unit', () => {});
-    
         assert.equal(specCollector.numberOfUnits, 1);
       });
     
@@ -104,7 +99,6 @@ spec('A `SpecCollector`', () => {
         const specCollector = new SpecCollector();
         specCollector.addUnit('1 unit', () => {});
         specCollector.addUnit('1 unit', () => {});
-    
         assert.equal(specCollector.numberOfUnits, 2);
       });
     
@@ -113,7 +107,6 @@ spec('A `SpecCollector`', () => {
         specCollector.addSpec('spec with one unit', () => {
           specCollector.addUnit('1 unit', () => {});
         });
-    
         assert.equal(specCollector.numberOfUnits, 1);
       });
     });
@@ -124,7 +117,6 @@ spec('A `SpecCollector`', () => {
         specCollector.addSpec('spec with one unit', () => {
           specCollector.addUnit('1 unit', () => {});
         });
-    
         assert.equal(specCollector.numberOfSpecs, 1);
       });
       
@@ -135,10 +127,8 @@ spec('A `SpecCollector`', () => {
             specCollector.addUnit('1 unit', () => {});
           });
         });
-    
         assert.equal(specCollector.numberOfSpecs, 2);
       });
     });
   });
-  
 });

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -64,16 +64,22 @@ spec('A `SpecCollector`', () => {
   });
 
   spec('collecting units (tests) via `addUnit()`', () => {
-    unit('stores the unit`s description', () => {
+    const addUnit = (desc) => {
       const specCollector = new SpecCollector();
-      const desc = 'description';
-  
+
       specCollector.addUnit(desc, () => {});
-  
-      const hasUnitDescription = unit => {
-        assert.equal(unit.description, desc);
-      };
-      specCollector.withEachUnit(hasUnitDescription);
+      return specCollector;
+    };
+    const descriptionsOf = (specCollector) => {
+      const descriptions = [];
+      specCollector.withEachUnit(unit => descriptions.push(unit.description));
+      return descriptions;
+    };
+
+    unit('stores the unit`s description', () => {
+      const desc = 'description';
+      const specCollector = addUnit(desc);
+      assert.deepEqual(descriptionsOf(specCollector), [desc]);
     });
   
     unit('stores empty descriptions', () => {

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -68,7 +68,6 @@ spec('A `SpecCollector`', () => {
   spec('collecting units (tests) via `addUnit()`', () => {
     const addUnit = (desc, testFn = noop, options = {}) => {
       const specCollector = new SpecCollector();
-
       specCollector.addUnit(desc, testFn, options);
       return specCollector;
     };
@@ -114,15 +113,13 @@ spec('A `SpecCollector`', () => {
       const description = 'my desc';
       const timeout = 1000;
       const referenceFunction = () => {};
-  
       const specCollector = addUnit(description, referenceFunction, { timeout });
   
-      const doWith = (unit) => {
-        assert(unit.description, description);
-        assert(unit.testFunction, referenceFunction);
+      specCollector.withEachUnit(unit => {
         assert(unit.timeout, timeout);
-      };
-      specCollector.withEachUnit(doWith);
+      });
+      assert.deepEqual(descriptionsOf(specCollector), [description]);
+      assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
     });
   });
   

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -2,38 +2,40 @@ const assert = require('assert');
 const { spec, unit } = require('../lib');
 const SpecCollector = require('../lib/unit-collector');
 
-spec('SpecCollector', () => {
-  unit('Providing 1 unit, SpecCollector finds 1 unit.', () => {
-    const specCollector = new SpecCollector();
-    specCollector.addUnit('1 unit', () => {});
-
-    assert.equal(specCollector.numberOfUnits, 1);
-  });
-
-  unit('Providing multiple units, SpecCollector finds them.', () => {
-    const specCollector = new SpecCollector();
-    specCollector.addUnit('1 unit', () => {});
-    specCollector.addUnit('1 unit', () => {});
-
-    assert.equal(specCollector.numberOfUnits, 2);
-  });
-
-  unit('Providing unit inside spec, SpecCollector finds the unit.', () => {
-    const specCollector = new SpecCollector();
-    specCollector.addSpec('spec with one unit', () => {
+spec('Given a `SpecCollector`', () => {
+  spec('provides statistics, when provided', () => {
+    unit('1 unit, it finds 1 unit.', () => {
+      const specCollector = new SpecCollector();
       specCollector.addUnit('1 unit', () => {});
+  
+      assert.equal(specCollector.numberOfUnits, 1);
     });
-
-    assert.equal(specCollector.numberOfUnits, 1);
-  });
-
-  unit('Providing unit inside spec, SpecCollector finds the spec.', () => {
-    const specCollector = new SpecCollector();
-    specCollector.addSpec('spec with one unit', () => {
+  
+    unit('multiple units, it finds them.', () => {
+      const specCollector = new SpecCollector();
       specCollector.addUnit('1 unit', () => {});
+      specCollector.addUnit('1 unit', () => {});
+  
+      assert.equal(specCollector.numberOfUnits, 2);
     });
-
-    assert.equal(specCollector.numberOfSpecs, 1);
+  
+    unit('unit inside spec, it finds the unit.', () => {
+      const specCollector = new SpecCollector();
+      specCollector.addSpec('spec with one unit', () => {
+        specCollector.addUnit('1 unit', () => {});
+      });
+  
+      assert.equal(specCollector.numberOfUnits, 1);
+    });
+  
+    unit('unit inside spec, it finds the spec.', () => {
+      const specCollector = new SpecCollector();
+      specCollector.addSpec('spec with one unit', () => {
+        specCollector.addUnit('1 unit', () => {});
+      });
+  
+      assert.equal(specCollector.numberOfSpecs, 1);
+    });
   });
 
   unit('When code inside spec throws, specCollector should stop.', () => {

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -2,6 +2,8 @@ const assert = require('assert');
 const { spec, unit } = require('../lib');
 const SpecCollector = require('../lib/unit-collector');
 
+const noop = () => {};
+
 spec('A `SpecCollector`', () => {
   spec('provides statistics', () => {
     spec('the number of units (via `numberOfUnits`), when provided', () => {
@@ -64,16 +66,21 @@ spec('A `SpecCollector`', () => {
   });
 
   spec('collecting units (tests) via `addUnit()`', () => {
-    const addUnit = (desc) => {
+    const addUnit = (desc, testFn = noop, options = {}) => {
       const specCollector = new SpecCollector();
 
-      specCollector.addUnit(desc, () => {});
+      specCollector.addUnit(desc, testFn, options);
       return specCollector;
     };
     const descriptionsOf = (specCollector) => {
       const descriptions = [];
       specCollector.withEachUnit(unit => descriptions.push(unit.description));
       return descriptions;
+    };
+    const testFunctionsOf = (specCollector) => {
+      const testFunctions = [];
+      specCollector.withEachUnit(unit => testFunctions.push(unit.testFunction));
+      return testFunctions;
     };
 
     unit('stores the unit`s description', () => {
@@ -83,41 +90,24 @@ spec('A `SpecCollector`', () => {
     });
   
     unit('stores empty descriptions', () => {
-      const specCollector = new SpecCollector();
       const emptyDesc = '';
-  
-      specCollector.addUnit(emptyDesc, () => {});
-  
-      const hasUnitDescription = unit => {
-        assert.equal(unit.description, emptyDesc);
-      };
-      specCollector.withEachUnit(hasUnitDescription);
+      const specCollector = addUnit(emptyDesc);
+      assert.deepEqual(descriptionsOf(specCollector), [emptyDesc]);
     });
   
     unit('stores the unit`s function', () => {
-      const specCollector = new SpecCollector();
       const referenceFunction = () => {};
-  
-      specCollector.addUnit('', referenceFunction);
-  
-      const hasUnitFunction = unit => {
-        assert.equal(unit.testFunction, referenceFunction);
-      };
-      specCollector.withEachUnit(hasUnitFunction);
+      const specCollector = addUnit('', referenceFunction);
+      assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
     });
   
     unit('collects unit`s description and function', () => {
-      const specCollector = new SpecCollector();
       const description = 'my desc';
       const referenceFunction = () => {};
   
-      specCollector.addUnit(description, referenceFunction);
-  
-      const doWith = (unit) => {
-        assert(unit.description, description);
-        assert(unit.testFunction, referenceFunction);
-      };
-      specCollector.withEachUnit(doWith);
+      const specCollector = addUnit(description, referenceFunction);
+      assert.deepEqual(descriptionsOf(specCollector), [description]);
+      assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
     });
   
     unit('collects timeout option for units', () => {

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -39,6 +39,17 @@ spec('A `SpecCollector`', () => {
     
         assert.equal(specCollector.numberOfSpecs, 1);
       });
+      
+      unit('a unit nested inside two specs, it finds two specs.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addSpec('spec with one spec and unit', () => {
+          specCollector.addSpec('spec with one unit', () => {
+            specCollector.addUnit('1 unit', () => {});
+          });
+        });
+    
+        assert.equal(specCollector.numberOfSpecs, 2);
+      });
     });
   });
 

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -71,21 +71,19 @@ spec('A `SpecCollector`', () => {
       specCollector.addUnit(desc, testFn, options);
       return specCollector;
     };
-    const descriptionsOf = (specCollector) => {
-      const descriptions = [];
-      specCollector.withEachUnit(unit => descriptions.push(unit.description));
-      return descriptions;
+
+    const valuesForAttribute = (specCollector, attribute) => {
+      const values = [];
+      specCollector.withEachUnit(unit => values.push(unit[attribute]));
+      return values;
     };
-    const testFunctionsOf = (specCollector) => {
-      const testFunctions = [];
-      specCollector.withEachUnit(unit => testFunctions.push(unit.testFunction));
-      return testFunctions;
-    };
-    const timeoutsOf = (specCollector) => {
-      const timeouts = [];
-      specCollector.withEachUnit(unit => timeouts.push(unit.timeout));
-      return timeouts;
-    };
+
+    const descriptionsOf = (specCollector) =>
+      valuesForAttribute(specCollector, 'description');
+    const testFunctionsOf = (specCollector) =>
+      valuesForAttribute(specCollector, 'testFunction');
+    const timeoutsOf = (specCollector) =>
+      valuesForAttribute(specCollector, 'timeout');
 
     unit('stores the unit`s description', () => {
       const desc = 'description';

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -55,7 +55,6 @@ spec('A `SpecCollector`', () => {
 
   unit('when a spec throws, it lets the error bubble up', () => {
     const specCollector = new SpecCollector();
-
     const fn = () => {
       specCollector.addSpec('spec that throws', () => {
         throw Error();
@@ -64,72 +63,74 @@ spec('A `SpecCollector`', () => {
     assert.throws(fn);
   });
 
-  unit('collects descriptions', () => {
-    const specCollector = new SpecCollector();
-    const desc = 'description';
-
-    specCollector.addUnit(desc, () => {});
-
-    const hasUnitDescription = unit => {
-      assert.equal(unit.description, desc);
-    };
-    specCollector.withEachUnit(hasUnitDescription);
+  spec('collecting units (tests) via `addUnit()`', () => {
+    unit('stores the unit`s description', () => {
+      const specCollector = new SpecCollector();
+      const desc = 'description';
+  
+      specCollector.addUnit(desc, () => {});
+  
+      const hasUnitDescription = unit => {
+        assert.equal(unit.description, desc);
+      };
+      specCollector.withEachUnit(hasUnitDescription);
+    });
+  
+    unit('stores empty descriptions', () => {
+      const specCollector = new SpecCollector();
+      const emptyDesc = '';
+  
+      specCollector.addUnit(emptyDesc, () => {});
+  
+      const hasUnitDescription = unit => {
+        assert.equal(unit.description, emptyDesc);
+      };
+      specCollector.withEachUnit(hasUnitDescription);
+    });
+  
+    unit('stores the unit`s function', () => {
+      const specCollector = new SpecCollector();
+      const referenceFunction = () => {};
+  
+      specCollector.addUnit('', referenceFunction);
+  
+      const hasUnitFunction = unit => {
+        assert.equal(unit.testFunction, referenceFunction);
+      };
+      specCollector.withEachUnit(hasUnitFunction);
+    });
+  
+    unit('collects unit`s description and function', () => {
+      const specCollector = new SpecCollector();
+      const description = 'my desc';
+      const referenceFunction = () => {};
+  
+      specCollector.addUnit(description, referenceFunction);
+  
+      const doWith = (unit) => {
+        assert(unit.description, description);
+        assert(unit.testFunction, referenceFunction);
+      };
+      specCollector.withEachUnit(doWith);
+    });
+  
+    unit('collects timeout option for units', () => {
+      const specCollector = new SpecCollector();
+      const description = 'my desc';
+      const timeout = 1000;
+      const referenceFunction = () => {};
+  
+      specCollector.addUnit(description, referenceFunction, { timeout });
+  
+      const doWith = (unit) => {
+        assert(unit.description, description);
+        assert(unit.testFunction, referenceFunction);
+        assert(unit.timeout, timeout);
+      };
+      specCollector.withEachUnit(doWith);
+    });
   });
-
-  unit('collects empty descriptions', () => {
-    const specCollector = new SpecCollector();
-    const emptyDesc = '';
-
-    specCollector.addUnit(emptyDesc, () => {});
-
-    const hasUnitDescription = unit => {
-      assert.equal(unit.description, emptyDesc);
-    };
-    specCollector.withEachUnit(hasUnitDescription);
-  });
-
-  unit('collects functions', () => {
-    const specCollector = new SpecCollector();
-    const referenceFunction = () => {};
-
-    specCollector.addUnit('', referenceFunction);
-
-    const hasUnitFunction = unit => {
-      assert.equal(unit.testFunction, referenceFunction);
-    };
-    specCollector.withEachUnit(hasUnitFunction);
-  });
-
-  unit('collects unit (description+fn).', () => {
-    const specCollector = new SpecCollector();
-    const description = 'my desc';
-    const referenceFunction = () => {};
-
-    specCollector.addUnit(description, referenceFunction);
-
-    const doWith = (unit) => {
-      assert(unit.description, description);
-      assert(unit.testFunction, referenceFunction);
-    };
-    specCollector.withEachUnit(doWith);
-  });
-
-  unit('collects timeout option for units.', () => {
-    const specCollector = new SpecCollector();
-    const description = 'my desc';
-    const timeout = 1000;
-    const referenceFunction = () => {};
-
-    specCollector.addUnit(description, referenceFunction, { timeout });
-
-    const doWith = (unit) => {
-      assert(unit.description, description);
-      assert(unit.testFunction, referenceFunction);
-      assert(unit.timeout, timeout);
-    };
-    specCollector.withEachUnit(doWith);
-  });
-
+  
   unit('collects specs.', () => {
     const specCollector = new SpecCollector();
 

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -81,6 +81,11 @@ spec('A `SpecCollector`', () => {
       specCollector.withEachUnit(unit => testFunctions.push(unit.testFunction));
       return testFunctions;
     };
+    const timeoutsOf = (specCollector) => {
+      const timeouts = [];
+      specCollector.withEachUnit(unit => timeouts.push(unit.timeout));
+      return timeouts;
+    };
 
     unit('stores the unit`s description', () => {
       const desc = 'description';
@@ -114,12 +119,9 @@ spec('A `SpecCollector`', () => {
       const timeout = 1000;
       const referenceFunction = () => {};
       const specCollector = addUnit(description, referenceFunction, { timeout });
-  
-      specCollector.withEachUnit(unit => {
-        assert(unit.timeout, timeout);
-      });
       assert.deepEqual(descriptionsOf(specCollector), [description]);
       assert.deepEqual(testFunctionsOf(specCollector), [referenceFunction]);
+      assert.deepEqual(timeoutsOf(specCollector), [timeout]);
     });
   });
   

--- a/tests/unit-collector.spec.js
+++ b/tests/unit-collector.spec.js
@@ -5,56 +5,6 @@ const SpecCollector = require('../lib/unit-collector');
 const noop = () => {};
 
 spec('A `SpecCollector`', () => {
-  spec('provides statistics', () => {
-    spec('the number of units (via `numberOfUnits`), when provided', () => {
-      unit('1 unit, it finds 1 unit.', () => {
-        const specCollector = new SpecCollector();
-        specCollector.addUnit('1 unit', () => {});
-    
-        assert.equal(specCollector.numberOfUnits, 1);
-      });
-    
-      unit('multiple units, it finds them.', () => {
-        const specCollector = new SpecCollector();
-        specCollector.addUnit('1 unit', () => {});
-        specCollector.addUnit('1 unit', () => {});
-    
-        assert.equal(specCollector.numberOfUnits, 2);
-      });
-    
-      unit('unit inside spec, it finds the unit.', () => {
-        const specCollector = new SpecCollector();
-        specCollector.addSpec('spec with one unit', () => {
-          specCollector.addUnit('1 unit', () => {});
-        });
-    
-        assert.equal(specCollector.numberOfUnits, 1);
-      });
-    });
-  
-    spec('the number of specs (via `numberOfSpecs`), when provided', () => {
-      unit('a unit inside a spec, it finds the spec.', () => {
-        const specCollector = new SpecCollector();
-        specCollector.addSpec('spec with one unit', () => {
-          specCollector.addUnit('1 unit', () => {});
-        });
-    
-        assert.equal(specCollector.numberOfSpecs, 1);
-      });
-      
-      unit('a unit nested inside two specs, it finds two specs.', () => {
-        const specCollector = new SpecCollector();
-        specCollector.addSpec('spec with one spec and unit', () => {
-          specCollector.addSpec('spec with one unit', () => {
-            specCollector.addUnit('1 unit', () => {});
-          });
-        });
-    
-        assert.equal(specCollector.numberOfSpecs, 2);
-      });
-    });
-  });
-
   unit('when a spec throws, it lets the error bubble up', () => {
     const specCollector = new SpecCollector();
     const fn = () => {
@@ -140,4 +90,55 @@ spec('A `SpecCollector`', () => {
       });
     });
   });
+  
+  spec('provides statistics', () => {
+    spec('the number of units (via `numberOfUnits`), when provided', () => {
+      unit('1 unit, it finds 1 unit.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addUnit('1 unit', () => {});
+    
+        assert.equal(specCollector.numberOfUnits, 1);
+      });
+    
+      unit('multiple units, it finds them.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addUnit('1 unit', () => {});
+        specCollector.addUnit('1 unit', () => {});
+    
+        assert.equal(specCollector.numberOfUnits, 2);
+      });
+    
+      unit('unit inside spec, it finds the unit.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addSpec('spec with one unit', () => {
+          specCollector.addUnit('1 unit', () => {});
+        });
+    
+        assert.equal(specCollector.numberOfUnits, 1);
+      });
+    });
+  
+    spec('the number of specs (via `numberOfSpecs`), when provided', () => {
+      unit('a unit inside a spec, it finds the spec.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addSpec('spec with one unit', () => {
+          specCollector.addUnit('1 unit', () => {});
+        });
+    
+        assert.equal(specCollector.numberOfSpecs, 1);
+      });
+      
+      unit('a unit nested inside two specs, it finds two specs.', () => {
+        const specCollector = new SpecCollector();
+        specCollector.addSpec('spec with one spec and unit', () => {
+          specCollector.addSpec('spec with one unit', () => {
+            specCollector.addUnit('1 unit', () => {});
+          });
+        });
+    
+        assert.equal(specCollector.numberOfSpecs, 2);
+      });
+    });
+  });
+  
 });


### PR DESCRIPTION
Eating own dog food.
Before the case of using the tests directory to find tests was hard coded, now it is a required parameter, which reduces the code and reduces magic.

Includes the PR #24 since code was written on top of it.