### PR TITLE
Reuse config internally

### DIFF
--- a/lib/file-loader.js
+++ b/lib/file-loader.js
@@ -11,7 +11,7 @@ const fileLoader = (loader) => {
     loadFiles(specFiles);
   };
 
-return {
+  return {
     load
   };
 };

--- a/lib/file-loader.js
+++ b/lib/file-loader.js
@@ -1,16 +1,13 @@
 const findFilesInDirectory = require('./utils/find-files-in-directory');
 
 const fileLoader = (loader) => {
-
-  const loadFiles = (pathToTheFiles) => pathToTheFiles.forEach(loader);
-
+  const loadOneFileWithLoader = (fileName) => loader(fileName);  
+  const loadFiles = (pathToTheFiles) => pathToTheFiles.forEach(loadOneFileWithLoader);
   const load = (path) => {
     const files = findFilesInDirectory(path);
     const specFiles = files.filter(file => file.indexOf('.spec') > -1);
-
     loadFiles(specFiles);
   };
-
   return {
     load
   };

--- a/lib/kavun.js
+++ b/lib/kavun.js
@@ -4,7 +4,7 @@ const uuidv4 = require("uuid/v4");
 const { startTimer } = require("./utils/time-tracker");
 
 const processId = uuidv4();
-startTimer(processId)
+startTimer(processId);
 
 const runner = require('./runner');
 const { unitCollector } = require('./index');
@@ -13,10 +13,6 @@ const fileLoader = require('./file-loader');
 const loader = fileLoader(require);
 const path = process.argv[2];
 
-if(path === undefined) {
-  loader.load(`${process.cwd()}/tests`);
-} else {
-  loader.load(`${process.cwd()}/${path}`);
-}
+loader.load(`${process.cwd()}/${path}`);
 
 runner(unitCollector, processId);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A test framework for Javascript",
   "bin": "./lib/kavun.js",
   "scripts": {
-    "test": "node lib/kavun.js"
+    "test": "node lib/kavun.js tests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Eating own dog food.
Before the case of using the tests directory to find tests was hard coded, now it is a required parameter, which reduces the code and reduces magic.
